### PR TITLE
fix iterator synth order, align std version

### DIFF
--- a/Straume/Iterator.lean
+++ b/Straume/Iterator.lean
@@ -105,4 +105,5 @@ def toList (src : α) [Iterable α β] : List β := toList' $ iter src
 -- i.e. `Char` can only be gotten by iterating over `String`s.
 class Bijection (β : Type u) (α : outParam (Type u))
 
+set_option synthInstance.checkSynthOrder false in
 instance [Iterable α β] : Bijection β α := {}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": 4,
- "packagesDir": "./lake-packages",
+ "packagesDir": "lake-packages",
  "packages":
  [{"git":
    {"url": "https://github.com/lurk-lab/YatimaStdLib.lean",
@@ -14,8 +14,8 @@
     "name": "LSpec",
     "inputRev?": "88f7d23e56a061d32c7173cea5befa4b2c248b41"}},
   {"git":
-   {"url": "https://github.com/leanprover/std4/",
+   {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "fde95b16907bf38ea3f310af406868fc6bcf48d1",
+    "rev": "6006307d2ceb8743fea7e00ba0036af8654d0347",
     "name": "std",
-    "inputRev?": "fde95b16907bf38ea3f310af406868fc6bcf48d1"}}]}
+    "inputRev?": "6006307d2ceb8743fea7e00ba0036af8654d0347"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,6 +5,9 @@ package Straume
 
 lean_lib Straume
 
+require std from git
+  "https://github.com/leanprover/std4" @ "6006307d2ceb8743fea7e00ba0036af8654d0347"
+
 require LSpec from git
   "https://github.com/lurk-lab/LSpec" @ "88f7d23e56a061d32c7173cea5befa4b2c248b41"
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-01-10
+leanprover/lean4:nightly-2023-05-06


### PR DESCRIPTION
This PR makes minimal changes necessary to bring `straume` to a more recent version of Lean 4.

More specifically, `instance [Iterable α β] : Bijection β α := {}` in `Iterator.lean` does not compile with the error:
`
cannot find synthesization order for instance`.

This furthermore uses a newer version of `std` as the one that is transitively cloned has minor issues in the linter tactic.